### PR TITLE
fix: harden security, propagate errors, and remove stale Blueprint dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,6 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-depends>serverSettings,graphql-dxm-provider,default</jahia-depends>
         <yarn.arguments>build:production</yarn.arguments>
-        <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"
-        </require-capability>
     </properties>
 
     <repositories>

--- a/src/javascript/ProvisioningGenerator/ProvisioningGenerator.jsx
+++ b/src/javascript/ProvisioningGenerator/ProvisioningGenerator.jsx
@@ -74,8 +74,7 @@ export const ProvisioningGeneratorAdmin = () => {
             } else {
                 setGenerateStatus('error');
             }
-        } catch (err) {
-            console.error('Failed to generate provisioning archive:', err);
+        } catch (_err) {
             setGenerateStatus('error');
         }
     };
@@ -89,8 +88,7 @@ export const ProvisioningGeneratorAdmin = () => {
         setGenerateStatus(null);
         try {
             await deleteArchive();
-        } catch (err) {
-            console.error('Failed to delete provisioning archive:', err);
+        } catch (_err) {
             setGenerateStatus('error');
         }
     };

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -1,5 +1,4 @@
 import('@jahia/app-shell/bootstrap').then(res => {
-    console.log(res);
     window.jahia = res;
     res.startAppShell(window.appShell.remotes, window.appShell.targetId);
 });

--- a/src/main/java/org/community/provisioninggenerator/command/GenerateCommand.java
+++ b/src/main/java/org/community/provisioninggenerator/command/GenerateCommand.java
@@ -21,6 +21,11 @@ public class GenerateCommand implements Action {
     public Object execute() throws Exception {
         final SettingsBean settingsBean = BundleUtils.getOsgiService(SettingsBean.class, null);
         final ProvisioningGeneratorService service = BundleUtils.getOsgiService(ProvisioningGeneratorService.class, null);
+        if (settingsBean == null || service == null) {
+            logger.error("Required OSGi services are not available");
+            return null;
+        }
+
         final File generatedFile = service.generate(settingsBean.getTmpContentDiskPath());
         logger.info("Provisioning archive generated at: {}", generatedFile.getAbsolutePath());
         return generatedFile.getAbsolutePath();

--- a/src/main/java/org/community/provisioninggenerator/services/ProvisioningGeneratorService.java
+++ b/src/main/java/org/community/provisioninggenerator/services/ProvisioningGeneratorService.java
@@ -51,11 +51,11 @@ public class ProvisioningGeneratorService {
                         try {
                             if (file.createNewFile()) {
                                 writeZip(file, filename, session);
-                            } else if (logger.isErrorEnabled()) {
-                                logger.error("Impossible to create file {}", filename);
+                            } else {
+                                throw new IOException("Impossible to create file " + filename);
                             }
                         } catch (IOException e) {
-                            logger.error("Error when creating zip", e);
+                            throw new RepositoryException("Error when creating zip", e);
                         }
                         return null;
                     });

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -4,6 +4,6 @@ TESTS_IMAGE=${TESTS_IMAGE:-jahia/provisioning-generator:latest}
 MODULE_ID=${MODULE_ID:-provisioning-generator}
 MANIFEST=${MANIFEST:-provisioning-manifest-snapshot.yml}
 JAHIA_URL=${JAHIA_URL:-http://jahia:8080}
-SUPER_USER_PASSWORD=${SUPER_USER_PASSWORD:-root1234}
+SUPER_USER_PASSWORD=${SUPER_USER_PASSWORD:-CHANGEME}
 JAHIA_LICENSE=${JAHIA_LICENSE:-""}
 JAHIA_HOST=${JAHIA_HOST:-jahia}

--- a/tests/cypress/e2e/01-provisioningGenerator.cy.ts
+++ b/tests/cypress/e2e/01-provisioningGenerator.cy.ts
@@ -14,7 +14,7 @@ describe('Provisioning Generator', () => {
         headers: {'Content-Type': 'application/json', Origin: Cypress.config('baseUrl')},
         auth: {
             username: Cypress.env('SUPER_USER_LOGIN') || 'root',
-            password: Cypress.env('SUPER_USER_PASSWORD') || 'root1234'
+            password: Cypress.env('SUPER_USER_PASSWORD')
         },
         failOnStatusCode: false
     };
@@ -43,7 +43,7 @@ describe('Provisioning Generator', () => {
             headers: {'Content-Type': 'application/yaml'},
             auth: {
                 username: Cypress.env('SUPER_USER_LOGIN') || 'root',
-                password: Cypress.env('SUPER_USER_PASSWORD') || 'root1234'
+                password: Cypress.env('SUPER_USER_PASSWORD')
             },
             body: '- karafCommand: "log:log \'provisioning-generator cypress test\'"'
         }).its('status').should('eq', 200);


### PR DESCRIPTION
## Summary

Remediation from a support code review covering architecture, security, code quality, and documentation.

## Changes (1 commit(s))

- fix: harden security, propagate errors, and remove stale Blueprint dependency

## Test plan

- `mvn clean install` succeeds
- Cypress E2E suite executed against Jahia EE 8.2 — passing.
