### PR TITLE
test: path-containment unit tests + harden generate() input validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,18 @@
             <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/community/provisioninggenerator/services/ProvisioningGeneratorService.java
+++ b/src/main/java/org/community/provisioninggenerator/services/ProvisioningGeneratorService.java
@@ -3,6 +3,7 @@ package org.community.provisioninggenerator.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.community.provisioninggenerator.BundleInstall;
+import org.community.provisioninggenerator.util.EntryNameSanitizer;
 import org.jahia.api.Constants;
 import org.jahia.api.content.JCRTemplate;
 import org.jahia.api.templates.JahiaTemplateManagerService;
@@ -34,6 +35,9 @@ public class ProvisioningGeneratorService {
     private static final Logger logger = LoggerFactory.getLogger(ProvisioningGeneratorService.class);
     private static final String QUERY = "SELECT * FROM [jnt:moduleManagementBundle] WHERE ISDESCENDANTNODE('/module-management/')"
             + " AND [j:groupId]='%s' AND [j:symbolicName]='%s' AND [j:version]='%s'";
+    private static final String EXPORT_FILE_PREFIX = "/modulesExport";
+    private static final String EXPORT_FILE_SUFFIX = ".zip";
+    private static final String MANIFEST_ENTRY_NAME = "provisioning.yaml";
 
     private volatile boolean generating = false;
 
@@ -42,9 +46,12 @@ public class ProvisioningGeneratorService {
     }
 
     public File generate(String tmpContentDiskPath) throws RepositoryException {
+        if (tmpContentDiskPath == null || tmpContentDiskPath.trim().isEmpty()) {
+            throw new IllegalArgumentException("tmpContentDiskPath must not be null or blank");
+        }
         generating = true;
         try {
-            final String filename = tmpContentDiskPath + "/modulesExport" + System.currentTimeMillis() + ".zip";
+            final String filename = tmpContentDiskPath + EXPORT_FILE_PREFIX + System.currentTimeMillis() + EXPORT_FILE_SUFFIX;
             final File file = new File(filename);
             BundleUtils.getOsgiService(JCRTemplate.class, null).doExecuteWithSystemSessionAsUser(
                     null, Constants.EDIT_WORKSPACE, null, session -> {
@@ -86,7 +93,7 @@ public class ProvisioningGeneratorService {
                             logger.error("Impossible to retrieve module", e);
                         }
                     });
-            final ZipEntry zipEntry = new ZipEntry("provisioning.yaml");
+            final ZipEntry zipEntry = new ZipEntry(MANIFEST_ENTRY_NAME);
             zipOutputStream.putNextEntry(zipEntry);
             zipOutputStream.write(objectMapper.writer().writeValueAsBytes(bundleKeys));
             zipOutputStream.closeEntry();
@@ -95,7 +102,7 @@ public class ProvisioningGeneratorService {
     }
 
     private void compressNode(JCRNodeWrapper node, ZipOutputStream zipOutputStream, List<BundleInstall> bundleKeys) {
-        final String nodeName = sanitizeEntryName(node.getName());
+        final String nodeName = EntryNameSanitizer.sanitize(node.getName());
         if (nodeName == null) {
             logger.warn("Skipping node with unsafe name");
             return;
@@ -114,15 +121,5 @@ public class ProvisioningGeneratorService {
         } catch (IOException | RepositoryException e) {
             logger.error("Impossible to retrieve module content", e);
         }
-    }
-
-    private static String sanitizeEntryName(String name) {
-        if (name == null || name.isEmpty()) {
-            return null;
-        }
-        if (name.contains("..") || name.contains("/") || name.contains("\\") || name.startsWith("/")) {
-            return null;
-        }
-        return name;
     }
 }

--- a/src/main/java/org/community/provisioninggenerator/util/EntryNameSanitizer.java
+++ b/src/main/java/org/community/provisioninggenerator/util/EntryNameSanitizer.java
@@ -1,0 +1,39 @@
+package org.community.provisioninggenerator.util;
+
+/**
+ * Validates ZIP entry names against path-traversal / zip-slip attacks.
+ *
+ * <p>Entry names are derived from JCR node names which are ultimately
+ * influenced by externally installed modules, so they are treated as
+ * untrusted input at this trust boundary. Only flat, relative names are
+ * accepted; any name containing path separators, parent references
+ * ({@code ..}) or a leading separator is rejected.
+ */
+public final class EntryNameSanitizer {
+
+    private static final String PARENT_REF = "..";
+    private static final String FORWARD_SLASH = "/";
+    private static final String BACKSLASH = "\\";
+
+    private EntryNameSanitizer() {
+    }
+
+    /**
+     * Returns the entry name when it is a safe, flat relative name; otherwise {@code null}.
+     *
+     * @param name the candidate ZIP entry name (may be {@code null})
+     * @return the validated name, or {@code null} if it is empty or unsafe
+     */
+    public static String sanitize(String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+        if (name.contains(PARENT_REF)
+                || name.contains(FORWARD_SLASH)
+                || name.contains(BACKSLASH)
+                || name.startsWith(FORWARD_SLASH)) {
+            return null;
+        }
+        return name;
+    }
+}

--- a/src/test/java/org/community/provisioninggenerator/util/EntryNameSanitizerTest.java
+++ b/src/test/java/org/community/provisioninggenerator/util/EntryNameSanitizerTest.java
@@ -1,0 +1,60 @@
+package org.community.provisioninggenerator.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EntryNameSanitizerTest {
+
+    @Test
+    public void returnsNameWhenFlatAndSafe() {
+        // Arrange
+        final String name = "my-module-1.0.0.jar";
+
+        // Act
+        final String result = EntryNameSanitizer.sanitize(name);
+
+        // Assert
+        assertThat(result).isEqualTo(name);
+    }
+
+    @Test
+    public void returnsNullWhenNameIsNull() {
+        assertThat(EntryNameSanitizer.sanitize(null)).isNull();
+    }
+
+    @Test
+    public void returnsNullWhenNameIsEmpty() {
+        assertThat(EntryNameSanitizer.sanitize("")).isNull();
+    }
+
+    @Test
+    public void rejectsParentDirectoryReference() {
+        assertThat(EntryNameSanitizer.sanitize("..")).isNull();
+        assertThat(EntryNameSanitizer.sanitize("..foo")).isNull();
+        assertThat(EntryNameSanitizer.sanitize("foo..bar")).isNull();
+    }
+
+    @Test
+    public void rejectsForwardSlashTraversal() {
+        assertThat(EntryNameSanitizer.sanitize("../../etc/passwd")).isNull();
+        assertThat(EntryNameSanitizer.sanitize("dir/file.jar")).isNull();
+    }
+
+    @Test
+    public void rejectsBackslashTraversal() {
+        assertThat(EntryNameSanitizer.sanitize("..\\..\\windows\\system32")).isNull();
+        assertThat(EntryNameSanitizer.sanitize("dir\\file.jar")).isNull();
+    }
+
+    @Test
+    public void rejectsLeadingForwardSlash() {
+        assertThat(EntryNameSanitizer.sanitize("/absolute.jar")).isNull();
+    }
+
+    @Test
+    public void acceptsNameWithDotsThatAreNotParentRef() {
+        assertThat(EntryNameSanitizer.sanitize("module.bundle.1.2.3.jar"))
+                .isEqualTo("module.bundle.1.2.3.jar");
+    }
+}


### PR DESCRIPTION
## Summary

Fleet-wide hardening pass for `provisioning-generator`. The prior commit (`3e4d591`) already addressed zip-slip, resource cleanup, error propagation and admin gating, so this PR closes the remaining genuine gap: **no automated tests** plus two small behavior-preserving robustness fixes.

## Changes

- **S1 — path containment (testable):** Extracted zip-entry name validation from `ProvisioningGeneratorService` into a focused, package-public `EntryNameSanitizer` util. Same rules (reject `..`, `/`, `\`, leading `/`), now unit-testable and DRY. Service delegates to it. Behavior-preserving.
- **S2 — null safety:** `generate(tmpContentDiskPath)` now rejects null/blank input with `IllegalArgumentException` before constructing the output file path (trust-boundary guard).
- **R1 — magic strings → constants:** Hoisted export file prefix/suffix and the `provisioning.yaml` manifest entry name into named constants.
- **R2 — tests:** Added test-scoped JUnit 4 (`${junit.version}` = 4.13.2, matching the parent's pinned surefire JUnit4 provider) + AssertJ; 8 unit tests over the path-traversal trust boundary.

## Verification

- `mvn clean install` — green; bundle jar produced.
- Surefire confirms tests actually execute: **Tests run: 8, Failures: 0, Errors: 0, Skipped: 0** (N>0, not a silent JUnit5-provider skip).

## Admin gating

Intact — all 4 GraphQL operations remain `@GraphQLRequiresPermission("admin")`. Not weakened.

## Notes

- Java 11 baseline unchanged; no pom compiler/version edits beyond adding test-scoped deps.
- No Docker/Cypress involved.