### PR TITLE
feat: add provisioningGeneratorAdmin permission for fine-grained RBAC

### DIFF
--- a/src/javascript/ProvisioningGenerator/register.jsx
+++ b/src/javascript/ProvisioningGenerator/register.jsx
@@ -6,7 +6,7 @@ export default () => {
     console.debug('%c provisioning-generator: activation in progress', 'color: #463CBA');
     registry.add('adminRoute', 'provisioningGenerator', {
         targets: ['administration-server-systemComponents:999'],
-        requiredPermission: 'admin',
+        requiredPermission: 'provisioningGeneratorAdmin',
         label: 'provisioning-generator:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(ProvisioningGeneratorAdmin)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <provisioningGeneratorAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/community/provisioninggenerator/graphql/ProvisioningGeneratorMutationExtension.java
+++ b/src/main/java/org/community/provisioninggenerator/graphql/ProvisioningGeneratorMutationExtension.java
@@ -37,7 +37,7 @@ public class ProvisioningGeneratorMutationExtension {
     @GraphQLField
     @GraphQLName("provisioningGeneratorGenerate")
     @GraphQLDescription("Generates a provisioning ZIP archive of all active Jahia modules and stores it in JCR")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("provisioningGeneratorAdmin")
     public static Boolean generate() {
         final SettingsBean settingsBean = BundleUtils.getOsgiService(SettingsBean.class, null);
         final ProvisioningGeneratorService service = BundleUtils.getOsgiService(ProvisioningGeneratorService.class, null);
@@ -69,7 +69,7 @@ public class ProvisioningGeneratorMutationExtension {
     @GraphQLField
     @GraphQLName("provisioningGeneratorDelete")
     @GraphQLDescription("Deletes the provisioning archive from JCR")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("provisioningGeneratorAdmin")
     public static Boolean delete() {
         try {
             BundleUtils.getOsgiService(JCRTemplate.class, null).doExecuteWithSystemSessionAsUser(

--- a/src/main/java/org/community/provisioninggenerator/graphql/ProvisioningGeneratorQueryExtension.java
+++ b/src/main/java/org/community/provisioninggenerator/graphql/ProvisioningGeneratorQueryExtension.java
@@ -31,7 +31,7 @@ public class ProvisioningGeneratorQueryExtension {
     @GraphQLField
     @GraphQLName("provisioningGeneratorIsGenerating")
     @GraphQLDescription("Returns true if a provisioning archive is currently being generated")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("provisioningGeneratorAdmin")
     public static Boolean isGenerating() {
         final ProvisioningGeneratorService service = BundleUtils.getOsgiService(ProvisioningGeneratorService.class, null);
         return service != null && service.isGenerating();
@@ -40,7 +40,7 @@ public class ProvisioningGeneratorQueryExtension {
     @GraphQLField
     @GraphQLName("provisioningGeneratorArchiveInfo")
     @GraphQLDescription("Returns archive metadata if the provisioning archive exists in JCR, null otherwise")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("provisioningGeneratorAdmin")
     public static GqlArchiveInfo archiveInfo() {
         try {
             return BundleUtils.getOsgiService(JCRTemplate.class, null).doExecuteWithSystemSessionAsUser(


### PR DESCRIPTION
## Summary

- Introduces `src/main/import/permissions.xml` defining `provisioningGeneratorAdmin` as a child permission of `admin` in JCR, so existing full-admin users retain access via privilege inheritance.
- Replaces all 4 `@GraphQLRequiresPermission("admin")` annotations across `ProvisioningGeneratorMutationExtension` and `ProvisioningGeneratorQueryExtension` with `@GraphQLRequiresPermission("provisioningGeneratorAdmin")`, enabling fine-grained RBAC for the provisioning-generator GraphQL API.
- No changes to Java logic, tests, or `pom.xml`.

## Test plan

- [ ] `mvn -q clean install` passes (verified locally — green)
- [ ] Deploy to Jahia and confirm that a full admin can still call `provisioningGeneratorGenerate`, `provisioningGeneratorDelete`, `provisioningGeneratorIsGenerating`, and `provisioningGeneratorArchiveInfo`
- [ ] Confirm that a non-admin user granted only `provisioningGeneratorAdmin` can call all four operations
- [ ] Confirm that a non-admin user without `provisioningGeneratorAdmin` is denied with a permissions error