### PR TITLE
test: add fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.jahia.community</groupId>
     <artifactId>provisioning-generator</artifactId>
     <name>Provisioning generator</name>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (Provisioning generator) for running on a Jahia server.</description>
     <scm>

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <provisioning-generator-administrator jcr:primaryType="jnt:role"
+                                          j:nodeTypes="rep:root"
+                                          j:roleGroup="server-role"
+                                          j:permissionNames="administrationAccess provisioningGeneratorAdmin"
+                                          j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Provisioning Generator administrator"
+                          jcr:description="Grants access to the Provisioning Generator administration without requiring full server administrator rights"/>
+    </provisioning-generator-administrator>
+</roles>

--- a/tests/cypress/e2e/03-provisioningGenerator-Permissions.cy.ts
+++ b/tests/cypress/e2e/03-provisioningGenerator-Permissions.cy.ts
@@ -1,0 +1,83 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `provisioningGeneratorAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("provisioningGeneratorAdmin")` is enforced as
+ *    `session.getNode("/").hasPermission("provisioningGeneratorAdmin")` (root-node ACL check).
+ *  - Frontend: `requiredPermission: 'provisioningGeneratorAdmin'` in register.jsx gates the admin route.
+ *  - RBAC content: the module ships the assignable `provisioning-generator-administrator` role
+ *    (src/main/import/roles.xml) granting ONLY that permission (+ `administrationAccess` for the UI entry).
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ */
+describe('Provisioning Generator — permission enforcement', () => {
+    const ROLE_NAME = 'provisioning-generator-administrator';
+    const DENIED_USER = 'pgDeniedUser';
+    const ALLOWED_USER = 'pgAllowedUser';
+    const PASSWORD = 'PgPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/provisioningGenerator';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const getArchiveInfo: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getArchiveInfo.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const queryArchiveInfoAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: getArchiveInfo});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            queryArchiveInfoAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            queryArchiveInfoAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                // Read-only query succeeds end-to-end; no archive present → null payload.
+                expect((result as {data: {provisioningGeneratorArchiveInfo: unknown}}).data)
+                    .to.have.property('provisioningGeneratorArchiveInfo');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.contains('h2', 'Provisioning Generator').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.contains('h2', 'Provisioning Generator', {timeout: 30000}).should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds an assignable admin role and Cypress regression tests that guard the fine-grained `provisioningGeneratorAdmin` permission across the whole stack (GraphQL backend, admin UI route, and RBAC content), so the module can be delegated without granting full server-administrator (`admin`) rights.

### Changes
- **`src/main/import/roles.xml`** (new): ships the assignable server-level role `provisioning-generator-administrator` granting **only** `administrationAccess provisioningGeneratorAdmin` — never `admin`. `administrationAccess` is required so the admin-UI entry renders for the delegated user.
- **`tests/cypress/e2e/03-provisioningGenerator-Permissions.cy.ts`** (new, 4 tests):
  - *GraphQL API authorization*
    - denies the gated read-only `provisioningGeneratorArchiveInfo` query for a user without the permission (asserts `Permission denied`)
    - allows it end-to-end for a user granted **only** the module role (asserts no errors + payload present)
  - *Admin UI authorization*
    - hides the admin panel from the denied user
    - shows the admin panel to the granted user at `/jahia/administration/provisioningGenerator`
  - The allowed user is granted the single-permission role and nothing else, proving fine-grained granularity rather than that a full admin passes.
- **`pom.xml`**: bump module version `2.0.2-SNAPSHOT` → `2.0.3-SNAPSHOT` so the new import content (roles.xml) is re-imported on deploy.

### Note on inner checks
No inner hardcoded server-level `admin` check exists in the resolvers — `ProvisioningGeneratorQueryExtension` / `ProvisioningGeneratorMutationExtension` rely solely on the `@GraphQLRequiresPermission("provisioningGeneratorAdmin")` annotation. **No Java relaxation was required.**

## Test plan
- `mvn clean install` (verified the fresh jar embeds `roles.xml`)
- Cleared stale `tests/artifacts/*-SNAPSHOT.jar`, then `./ci.build.sh && ./ci.startup.sh`
- Result: **14/14 specs pass** (01: 6/6, 02: 4/4, 03: 4/4 — new spec fully green, no regressions)
- License health clean (0 license errors in jahia logs)